### PR TITLE
v1.3.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## Strength
 
-Estimated development ELO (v2.0.0): ~3088
+Estimated development ELO (v1.3.0): ~3108
 
 **Official [CCRL ELO (v1.2.0)](http://ccrl.chessdom.com/ccrl/4040/cgi/engine_details.cgi?print=Details&each_game=1&eng=Avalanche%201.2.0%2064-bit#Avalanche_1_2_0_64-bit): 3042**
 
@@ -70,11 +70,12 @@ Parameter Tuning is done by my [Storming Tune](https://github.com/SnowballSH/sto
 
 ## Changelog
 
-- ### WIP: v2.0.0 (+46 ELO) ~3088 ELO
+- ### v1.3.0 (+66 ELO) ~3108 ELO
 
   - Stronger Neural Network trained on 2GB of data
   - Countermove Heuristics
   - Higher bounds for History Heuristics
+  - Improved Aspiration Window
 
 - ### v1.2.0 (+201 ELO) 3042 CCRL ELO
 

--- a/build.zig
+++ b/build.zig
@@ -101,9 +101,9 @@ pub fn build(b: *std.build.Builder) void {
         build_options.addOption(usize, "OUTPUT_SIZE", @intCast(usize, output_size));
     }
 
-    var buf: [64]u8 = undefined;
-    build_options.addOption([]const u8, "version", dtToString(timestamp2DateTime(std.time.timestamp()), &buf));
-    // build_options.addOption([]const u8, "version", "1.2.0");
+    // var buf: [64]u8 = undefined;
+    // build_options.addOption([]const u8, "version", dtToString(timestamp2DateTime(std.time.timestamp()), &buf));
+    build_options.addOption([]const u8, "version", "1.3.0");
 
     exe.use_stage1 = true;
 

--- a/src/engine/parameters.zig
+++ b/src/engine/parameters.zig
@@ -11,5 +11,5 @@ pub const NMPBetaDivisor = 214;
 
 pub const RazoringMargin = 350;
 
-pub const AspirationWindow = 15;
-pub const AspirationWindowBonus = 1.31;
+pub const AspirationWindow = 24;
+pub const AspirationWindowBonus = 0.15;


### PR DESCRIPTION
```
Result:
-----------------------------------------------------------------------------
  #  name             games    wins   draws  losses   score    elo    +    -
  1. Avalanche 1.3.0      28       9      17       2    17.5     33   49   47
  2. Avalanche 1.2.0     28       2      17       9    10.5    -33   47   49

Tech
  #  name               nodes/m         NPS  depth/m   time/m    moves     time
  1. Avalanche 1.3.0       3864K     1178952     19.8      3.3     55.1    180.7
  2. Avalanche 1.2.0      3436K     1049836     19.4      3.3     55.4    181.2
     all ---              3563K     1114310     19.6      3.3     55.2    180.9
```
